### PR TITLE
updating og:image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,7 @@
     <meta data-react-helmet="true" property="og:url" content="%REACT_APP_CANONICAL_ROOT%%PUBLIC_URL%/" />
     <meta data-react-helmet="true" property="og:site_name" content="%REACT_APP_META_TITLE%" />
     <meta data-react-helmet="true" property="og:description" content="%REACT_APP_META_DESCRIPTION%" />
-    <meta data-react-helmet="true" property="og:image" href="%REACT_APP_CANONICAL_ROOT%%REACT_APP_META_IMAGE_RELATIVE_PATH%">
+    <meta data-react-helmet="true" property="og:image" href="%REACT_APP_META_IMAGE%">
 
     <link data-react-helmet="true" rel="canonical" href="%REACT_APP_CANONICAL_ROOT%%PUBLIC_URL%/" />
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -70,7 +70,7 @@ export const CANONICAL_ROOT = process.env.REACT_APP_CANONICAL_ROOT || 'https://c
 
 // meta tag content
 export const META_TITLE = process.env.REACT_APP_META_TITLE || 'Barnes Collection Online';
-export const META_IMAGE = CANONICAL_ROOT + process.env.REACT_APP_META_IMAGE_RELATIVE_PATH || '';
+export const META_IMAGE = process.env.REACT_APP_META_IMAGE || '';
 export const META_DESCRIPTION = process.env.REACT_APP_META_DESCRIPTION || '';
 export const META_PLACENAME = process.env.REACT_APP_META_PLACENAME || '';
 


### PR DESCRIPTION
With this change, we will want to change the .env file.

You can remove ```REACT_APP_META_IMAGE_RELATIVE_PATH=...```
and add this:
```
REACT_APP_META_IMAGE=https://s3.amazonaws.com/barnes-image-repository/images/5003_92ad85ffeb13d697_n.jpg
```

It's safe to do this after a push, the site won't break. The image will just be wrong until the change is made.