### PR TITLE
Prerender api from node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { render } from 'react-dom';
 import App from './App';
 import { configureStore } from './store';
 import registerServiceWorker from './registerServiceWorker';
+import { unregister as unregisterServiceWorker } from './registerServiceWorker';
 
 const store = configureStore(window.__INITIAL_STATE__);
 const mountApp = document.getElementById('root');
@@ -25,4 +26,10 @@ render(
 //     );
 //   });
 // }
-registerServiceWorker();
+
+// registerServiceWorker();
+
+// disable this service and clear the 'cache' for users who registered with it before.
+// this seems to be messing with the prerendering
+// for details, see ./registerServiceWorker and the documentation link mentioned there.
+unregisterServiceWorker();


### PR DESCRIPTION
This gets rid of the serviceworker that setups up some fancy 'offline' mode caching which is not needed and which messes with our prerendering.