### PR TITLE
Dev eric

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -3,4 +3,3 @@
 
 @import './components-barnes-toolkit/scss/app.scss';
 @import './scss/styleguide-extend.scss';
-@import './scss/third-party/flickity.css';


### PR DESCRIPTION
removing flickity css which is already included in the style guide …
the css was gitignored so causing an error. I was going to change this
to a .scss, but turns out it’s already bundled in the style guide
anyway .