### PR TITLE
Refactor /api/related to act on sorted objects

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -255,7 +255,7 @@ const getDistance = (from, to) => {
     return sum + Math.pow(absoluteDistance, 2)
   }, 0)
 
-  return distance / distanceKeys.length
+  return distanceKeys.length > 0 ? distance / distanceKeys.length : Infinity
 }
 
 app.get('/api/related', (req, res) => {

--- a/src/actions/filters.js
+++ b/src/actions/filters.js
@@ -20,20 +20,6 @@ export function removeFilter(filter) {
   }
 }
 
-export function removeFilterByIndex(index) {
-  return {
-    type: ActionTypes.REMOVE_FILTER_BY_INDEX,
-    index: index
-  }
-}
-
-export function removeFilterBySlug(slug) {
-  return {
-    type: ActionTypes.REMOVE_FILTER_BY_SLUG,
-    slug: slug
-  }
-}
-
 export function clearAllFilters() {
   return {
     type: ActionTypes.CLEAR_ALL_FILTERS

--- a/src/actions/objects.js
+++ b/src/actions/objects.js
@@ -308,23 +308,24 @@ const buildQueriesFromFilters = (filters) => {
           queries.push(buildColorQuery(query));
         })
         break;
-      case 'line':
-        if (filter.filterGroup === 'composition') {
-          queries.push(buildRangeQuery(filter.name, { 'gte': BARNES_SETTINGS.line_threshhold }));
-        } else if (filter.filterGroup === 'linearity') {
-          switch (filter.name) {
-            case 'unbroken':
-              queries.push(buildRangeQuery('line', { 'lte': BARNES_SETTINGS.broken_threshhold }));
-              break;
-            case 'broken':
-              queries.push(buildRangeQuery('line', { 'gte': BARNES_SETTINGS.broken_threshhold }));
-              break;
-            case 'all types':
-              break;
-            default:
-              break;
-          }
+      case 'lineComposition':
+        queries.push(buildRangeQuery(filter.name, { 'gte': BARNES_SETTINGS.line_threshhold }));
+        break;
+      case 'lineLinearity':
+        switch (filter.name) {
+          case 'unbroken':
+            queries.push(buildRangeQuery('line', { 'lte': BARNES_SETTINGS.broken_threshhold }));
+            break;
+          case 'broken':
+            queries.push(buildRangeQuery('line', { 'gte': BARNES_SETTINGS.broken_threshhold }));
+            break;
+          case 'all types':
+            break;
+          default:
+            throw 'unexpected filterType';
+            break;
         }
+
         break;
       case 'light':
         queries.push(buildRangeQuery(filter.name, { 'lte': ((filter.value/100) + .01) }));

--- a/src/components/CollectionFilters/Filter.jsx
+++ b/src/components/CollectionFilters/Filter.jsx
@@ -18,22 +18,19 @@ class Filter extends Component {
     this.handleSliderFilter = this.handleSliderFilter.bind(this);
   }
 
-  filterIsApplied() {
-    const filters = this.props.filters.ordered;
-    for (let i = 0; i < filters.length; i++) {
-      if (filters[i].slug === this.props.filter.slug) {
-        return i;
-      }
-    }
-    return -1;
+  isFilterApplied() {
+    return this.props.filters.ordered.filter((filter) => {
+      return filter.slug === this.props.filter.slug;
+    }).length > 0;
   }
 
   handleButtonFilter() {
     const filter = this.props.filter;
-    if (this.props.filters.ordered.length === 0 || this.filterIsApplied() === -1) {
-      this.props.addFilter(filter);
-    } else {
+
+    if (this.isFilterApplied()) {
       this.props.removeFilter(filter);
+    } else {
+      this.props.addFilter(filter);
     }
   }
 
@@ -48,7 +45,7 @@ class Filter extends Component {
     // todo: this is kind of a quick fix. Maybe this should be defined in a more structured way.
     const isRadioStyle = filter.filterGroup === 'linearity';
 
-    let classes = 'btn ';
+    let classes = 'btn btn-filter ';
     classes += filter.filterType + '-filter';
 
     switch(filter.filterType) {
@@ -67,7 +64,7 @@ class Filter extends Component {
       classes += ' filter-style-radio';
     }
 
-    if (this.filterIsApplied() > -1) {
+    if (this.isFilterApplied()) {
       classes += ' is-applied';
     }
 
@@ -82,7 +79,8 @@ class Filter extends Component {
           style={{background: this.props.filter.color}}
           classes={this.getClasses()}
           />;
-      case 'line':
+      case 'lineComposition':
+      case 'lineLinearity':
         return <LineFilter
           handleClick={this.handleButtonFilter}
           classes={this.getClasses()}

--- a/src/components/CollectionFilters/LineFilters.jsx
+++ b/src/components/CollectionFilters/LineFilters.jsx
@@ -11,6 +11,8 @@ import Filter from './Filter';
 class LineFilters extends Component {
   buildFilters(type) {
     const filters = this.props.filterSets.sets.lines.options[type];
+
+
     return (
       filters.map((option, index) => {
         option.filterGroup = type;

--- a/src/components/CollectionFilters/collectionFilters.scss
+++ b/src/components/CollectionFilters/collectionFilters.scss
@@ -86,7 +86,7 @@
   justify-content: center;
   height: 50px;
 
-  .color-filter {
+  .btn-filter {
     flex-grow: 1;
     height: 100%;
     width: auto;
@@ -108,7 +108,7 @@
   justify-content: space-between;
   align-items: flex-start;
 
-  .line-filter {
+  .btn-filter {
     height: 50px;
     min-height: 0;
     padding: 0 20px;

--- a/src/reducers/filterSets.js
+++ b/src/reducers/filterSets.js
@@ -73,7 +73,7 @@ const buildInitialState = () => {
 
   for (let i = 0; i < LINE_FILTERS.composition.length; i++) {
     let lineFilter = LINE_FILTERS.composition[i];
-    lineFilter.filterType = 'line';
+    lineFilter.filterType = 'lineComposition';
     lineFilter.slug = 'line-'+lineFilter.name;
     lineFilter.svgId = lineFilter.svgId;
 
@@ -82,7 +82,7 @@ const buildInitialState = () => {
 
   for (let i = 0; i < LINE_FILTERS.linearity.length; i++) {
     let lineFilter = LINE_FILTERS.linearity[i];
-    lineFilter.filterType = 'line';
+    lineFilter.filterType = 'lineLinearity';
     lineFilter.slug = 'line-'+lineFilter.name;
     lineFilter.svgId = lineFilter.svgId;
 

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -21,13 +21,14 @@ const filters = (state = initialState, action) => {
 
   switch(action.type) {
     case ActionTypes.ADD_FILTER:
-      // clean the set
-      state.ordered = removeFromOrderedSet(state.ordered, filterType);
+      // Clone it
+      let supplementedState = Object.assign({}, state);
 
-      // add the new one to the ordered set
-      let supplementedState = Object.assign({}, state, {
-        ordered: [...state.ordered, action.filter]
-      });
+      debugger;
+      // first clean it up since there can be only one filter of each type now
+      supplementedState.ordered = removeFromOrderedSet(state.ordered, filterType);
+      // and add the new one to the ordered set
+      supplementedState.ordered.push(action.filter);
 
       // the all types works differently -- it acts as a clear
       if (filterType === 'lineLinearity' && action.filter.name === 'all types') {
@@ -35,15 +36,13 @@ const filters = (state = initialState, action) => {
       } else {
         supplementedState[filterType] = action.filter;
       }
-
       return supplementedState;
     case ActionTypes.REMOVE_FILTER:
-      state.ordered = removeFromOrderedSet(state.ordered, filterType);
+      // clone it
+      let reducedState = Object.assign({}, state);
 
-      let reducedState = Object.assign({}, state, {
-        ordered: state.ordered
-      });
-
+      // and clean up the state
+      reducedState.ordered = removeFromOrderedSet(state.ordered, filterType);
       reducedState[filterType] = null;
 
       return reducedState;

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -2,74 +2,51 @@ import * as ActionTypes from '../constants';
 import { selectRandomFilters } from '../reducers/filterSets';
 
 const initialState = {
-  colors: [],
+  colors: null,
   line: {
     composition: null,
-    linearity: null
+    linearity: null,
   },
   light: null,
   space: null,
-  ordered: []
+  ordered: [],
 };
 
+const removeFromOrderedSet = (orderedSet, filterType) => {
+  return orderedSet.filter((filterEl) => {
+    return filterEl.filterType !== filterType;
+  });
+}
+
 const filters = (state = initialState, action) => {
+  const filterType = action.filter ? action.filter.filterType : null;
+
   switch(action.type) {
     case ActionTypes.ADD_FILTER:
+      // clean the set
+      state.ordered = removeFromOrderedSet(state.ordered, filterType);
+
+      // add the new one to the ordered set
       let supplementedState = Object.assign({}, state, {
         ordered: [...state.ordered, action.filter]
       });
 
-      switch (action.filter.filterType) {
-        case 'color':
-          supplementedState.colors = [...state.colors, action.filter];
-          break;
-        case 'line':
-          supplementedState = addLineFilter(supplementedState, action.filter);
-          break;
-        case 'light':
-          if (state.light) {
-            supplementedState.ordered = getReducedFilters(supplementedState.ordered, state.light.slug);
-          }
-          supplementedState.light = action.filter;
-          break;
-        case 'space':
-          if (state.space) {
-            supplementedState.ordered = getReducedFilters(supplementedState.ordered, state.space.slug);
-          }
-          supplementedState.space = action.filter;
-          break;
-        default:
-          break;
+      // temp exception
+      if (filterType === 'line') {
+        supplementedState = addLineFilter(supplementedState, action.filter);
+      } else {
+        supplementedState[filterType] = action.filter;
       }
-      supplementedState.ordered = [...new Set(supplementedState.ordered)];
+
       return supplementedState;
     case ActionTypes.REMOVE_FILTER:
+      state.ordered = removeFromOrderedSet(state.ordered, filterType);
+
       let reducedState = Object.assign({}, state, {
-        ordered: getReducedFilters(state.ordered, action.filter.slug)
+        ordered: state.ordered
       });
 
-      switch (action.filter.filterType) {
-        case 'color':
-          reducedState.colors = getReducedFilters(state.colors, action.filter.slug);
-          break;
-        case 'line':
-          reducedState = removeLineFilter(state, reducedState, action.filter);
-          break;
-        case 'light':
-          reducedState.light = null;
-          break;
-        case 'space':
-          reducedState.space = null;
-          break;
-        default:
-          break;
-      }
       return reducedState;
-    case ActionTypes.REMOVE_FILTER_BY_INDEX:
-      return [...state.slice(0, action.index), ...state.slice(action.index + 1)];
-    case ActionTypes.REMOVE_FILTER_BY_SLUG:
-      const index = findIndexBySlug(state, action.slug);
-      return [...state.slice(0, index), ...state.slice(index+1)];
     case ActionTypes.CLEAR_ALL_FILTERS:
       return initialState;
     case ActionTypes.SHUFFLE_FILTERS:
@@ -78,43 +55,10 @@ const filters = (state = initialState, action) => {
         ordered: filters
       });
 
-      filters.forEach((filter) => {
-        switch (filter.filterType) {
-          case 'color':
-            shuffledState.colors.push(filter);
-            break;
-          case 'line':
-            if (filter.filterGroup === 'composition') {
-              shuffledState.line.composition = filter;
-            } else if (filter.filterGroup === 'linearity') {
-              filter.name === 'all types' ? shuffledState.line.linearity = null : shuffledState.line.linearity = filter;
-            }
-            break;
-          case 'light':
-            shuffledState.light = filter;
-            break;
-          case 'space':
-            shuffledState.space = filter;
-            break;
-          default:
-            break;
-        }
-      });
       return shuffledState;
     default:
       return state;
   }
-}
-
-const removeLineFilter = (state, reducedState, filter) => {
-  if (filter.filterGroup === 'composition') {
-    reducedState.line.composition = getReducedFilters(state.line.composition, filter.slug);
-  } else if (filter.filterGroup === 'linearity') {
-    if (!filter.name === 'all types') {
-      reducedState.line.linearity = getReducedFilters(state.line.linearity, filter.slug);
-    }
-  }
-  return reducedState;
 }
 
 const addLineFilter = (state, filter) => {
@@ -123,41 +67,14 @@ const addLineFilter = (state, filter) => {
     linearity: null
   };
 
-  if (filter.filterGroup === 'composition') {
-    state.line.composition = state.line.composition ? [...state.line.composition, filter] : [filter];
-  } else if (filter.filterGroup === 'linearity') {
-    if (filter.name !== 'all types') {
-      state.line.linearity = filter.name;
-      state.ordered = getReducedFilters(state.ordered, 'line-all types');
-      filter.name === 'broken' ? state.ordered = getReducedFilters(state.ordered, 'line-unbroken') : state.ordered = getReducedFilters(state.ordered, 'line-broken');
-    } else {
-      state.line.linearity = null;
-      state.ordered = getReducedFilters(state.ordered, 'line-unbroken');
-      state.ordered = getReducedFilters(state.ordered, 'line-broken');
-    }
+  state.line[filter.filterGroup] = filter;
+
+  // todo - try to remove special cases
+  if (filter.filterGroup === 'linearity' && filter.name === 'all types') {
+    state.line.linearity = null;
   }
+
   return state;
-}
-
-const getReducedFilters = (filters, slug) => {
-  const index = findIndexBySlug(filters, slug);
-  if (index > -1) {
-    return [
-      ...filters.slice(0, index),
-      ...filters.slice(index + 1)
-    ];
-  } else {
-    return filters;
-  }
-}
-
-const findIndexBySlug = (filters, slug) => {
-  for (let i = 0; i < filters.length; i++) {
-    if (filters[i].slug === slug) {
-      return i;
-    }
-  }
-  return -1;
 }
 
 export default filters;

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -3,10 +3,8 @@ import { selectRandomFilters } from '../reducers/filterSets';
 
 const initialState = {
   colors: null,
-  line: {
-    composition: null,
-    linearity: null,
-  },
+  lineComposition: null,
+  lineLinearity: null,
   light: null,
   space: null,
   ordered: [],
@@ -31,9 +29,9 @@ const filters = (state = initialState, action) => {
         ordered: [...state.ordered, action.filter]
       });
 
-      // temp exception
-      if (filterType === 'line') {
-        supplementedState = addLineFilter(supplementedState, action.filter);
+      // the all types works differently -- it acts as a clear
+      if (filterType === 'lineLinearity' && action.filter.name === 'all types') {
+        supplementedState[filterType] = null;
       } else {
         supplementedState[filterType] = action.filter;
       }
@@ -45,6 +43,8 @@ const filters = (state = initialState, action) => {
       let reducedState = Object.assign({}, state, {
         ordered: state.ordered
       });
+
+      reducedState[filterType] = null;
 
       return reducedState;
     case ActionTypes.CLEAR_ALL_FILTERS:
@@ -59,22 +59,6 @@ const filters = (state = initialState, action) => {
     default:
       return state;
   }
-}
-
-const addLineFilter = (state, filter) => {
-  state.line = state.line || {
-    composition: null,
-    linearity: null
-  };
-
-  state.line[filter.filterGroup] = filter;
-
-  // todo - try to remove special cases
-  if (filter.filterGroup === 'linearity' && filter.name === 'all types') {
-    state.line.linearity = null;
-  }
-
-  return state;
 }
 
 export default filters;

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -24,7 +24,6 @@ const filters = (state = initialState, action) => {
       // Clone it
       let supplementedState = Object.assign({}, state);
 
-      debugger;
       // first clean it up since there can be only one filter of each type now
       supplementedState.ordered = removeFromOrderedSet(state.ordered, filterType);
       // and add the new one to the ordered set

--- a/src/reducers/mobileFilters.js
+++ b/src/reducers/mobileFilters.js
@@ -15,11 +15,9 @@ const mobileFilters = (state = initialState, action) => {
     case ActionTypes.QUEUE_MOBILE_FILTERS:
       return Object.assign({}, state, { filtersPending: true });
     case ActionTypes.APPLY_MOBILE_FILTERS:
-      // if (action.filters.length) {
-        return Object.assign({}, state, {
-          filtersApplied: true
-        });
-      // }
+      return Object.assign({}, state, {
+        filtersApplied: true
+      });
     case ActionTypes.RESET_MOBILE_FILTERS:
       return Object.assign({}, state, {
         filtersPending: false,


### PR DESCRIPTION
Simplified the selection of objects - it sorts them all, then just selects the N closest and 1 - N furthers objects.

We can expand that selection, but this should now work, even if we have only one text descriptor, like for object 4691