### PR TITLE
Dev eric

### DIFF
--- a/src/components/ArtObjectPageComponents/ArtObjectPageModal/index.jsx
+++ b/src/components/ArtObjectPageComponents/ArtObjectPageModal/index.jsx
@@ -11,7 +11,6 @@ class ModalArtObjectPage extends Component {
   constructor(props) {
     super(props);
 
-    this.props.modalShow();
     this.state = this.getState(this.props);
   }
 
@@ -25,7 +24,11 @@ class ModalArtObjectPage extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidMount(nextProps) {
+    this.props.modalShow();
+  }
+
+  componentWillUpdate(nextProps) {
     if (this.props.match.params !== nextProps.match.params) {
       this.setState(this.getState(nextProps));
     }

--- a/src/layouts/LandingPage/LandingPage.jsx
+++ b/src/layouts/LandingPage/LandingPage.jsx
@@ -57,7 +57,6 @@ class LandingPage extends Component {
 function mapStateToProps(state) {
   return {
     object: state.object,
-    modalIsOpen: state.modal.modalIsOpen,
   };
 }
 

--- a/src/routeSwitcher.jsx
+++ b/src/routeSwitcher.jsx
@@ -30,6 +30,11 @@ class RouteSwitcher extends Component {
 
   componentWillUpdate(nextProps) {
     const { location } = this.props
+    const nextLocation = nextProps.location
+    const locationState = nextLocation.state || {};
+
+    debugger;
+
     // set modalPreviousLocation if props.location is not modal
     if (
       nextProps.history.action !== 'POP' &&
@@ -37,16 +42,8 @@ class RouteSwitcher extends Component {
     ) {
       this.modalPreviousLocation = this.props.location
     }
-  }
 
-  render() {
-    const { location } = this.props
-    const locationState = location.state || {};
-
-    let isModal = !!(
-      locationState.isModal &&
-      this.modalPreviousLocation !== location // not initial render
-    )
+    let isModal = locationState.isModal;
 
     let modalPreviousLocation = locationState.modalPreviousLocation ? {
       pathname: locationState.modalPreviousLocation,
@@ -60,6 +57,39 @@ class RouteSwitcher extends Component {
       });
     }
 
+    this.switchLocation = isModal ? modalPreviousLocation : nextLocation
+
+    this.modalDivs = isModal ?
+      (<div>
+        <PropsRoute exact path='/objects/:id'
+          component={ArtObjectPageModal}
+          isModal={true}
+          modalPreviousLocation={modalPreviousLocation.pathname || null}
+        />
+        <PropsRoute exact path='/objects/:id/:panel'
+          component={ArtObjectPageModal}
+          isModal={true}
+          modalPreviousLocation={modalPreviousLocation.pathname || null}
+        />
+      </div>)
+      : null
+  }
+
+  render() {
+    debugger;
+
+    const { location } = this.props
+    const locationState = location.state || {};
+
+    let isModal = !!(
+      locationState.isModal &&
+      this.modalPreviousLocation !== location // not initial render
+    )
+
+    let modalPreviousLocation = locationState.modalPreviousLocation ? {
+      pathname: locationState.modalPreviousLocation,
+    } : this.modalPreviousLocation;
+
     return (
       <div>
         <Switch location={isModal ? modalPreviousLocation : location}>
@@ -67,21 +97,7 @@ class RouteSwitcher extends Component {
           <Route exact path='/objects/:id' component={ArtObjectPage}/>
           <Route exact path='/objects/:id/:panel' component={ArtObjectPage} />
         </Switch>
-        {isModal ?
-          <div>
-            <PropsRoute exact path='/objects/:id'
-              component={ArtObjectPageModal}
-              isModal={isModal}
-              modalPreviousLocation={modalPreviousLocation.pathname || null}
-            />
-            <PropsRoute exact path='/objects/:id/:panel'
-              component={ArtObjectPageModal}
-              isModal={isModal}
-              modalPreviousLocation={modalPreviousLocation.pathname || null}
-            />
-          </div>
-          : null
-        }
+        {this.modalDivs}
       </div>
     )
   }

--- a/src/routeSwitcher.jsx
+++ b/src/routeSwitcher.jsx
@@ -33,8 +33,6 @@ class RouteSwitcher extends Component {
     const nextLocation = nextProps.location
     const locationState = nextLocation.state || {};
 
-    debugger;
-
     // set modalPreviousLocation if props.location is not modal
     if (
       nextProps.history.action !== 'POP' &&
@@ -76,8 +74,6 @@ class RouteSwitcher extends Component {
   }
 
   render() {
-    debugger;
-
     const { location } = this.props
     const locationState = location.state || {};
 
@@ -105,7 +101,6 @@ class RouteSwitcher extends Component {
 
 function mapStateToProps(state) {
   return {
-    modalIsOpen: state.modal.modalIsOpen,
     modalParentState: state.modal.modalParentState,
   };
 }


### PR DESCRIPTION
Fixing https://trello.com/c/GOJ33mDU/227-navigating-backwards-from-a-object-page-back-to-a-search-result-page-almost-always-results-in-the-view-more-button-disappearing.

The issue had to do with trying to set state in the wrong places -- like render functions and constructors. They needed to be moved to functions like componentDidMount