### PR TITLE
Solving for sticky artObject on artObject page

### DIFF
--- a/src/components/ArtObjectPageComponents/ArtObjectPageShell/index.scss
+++ b/src/components/ArtObjectPageComponents/ArtObjectPageShell/index.scss
@@ -17,6 +17,13 @@
     }
   }
 
+  .component-modal & {
+    // override - no need to clear the header
+    .art-object__image-container {
+      top: 0;
+    }
+  }
+
   .art-object__title {
     text-align: center;
     margin: 0 0 2rem 0;
@@ -37,6 +44,22 @@
   }
 
   .art-object__image-container {
+    position: sticky;
+    top: $g-header-height-xsmall;
+
+    // match the header heights in the styleguide
+    @include breakpoint('medium+') {
+      top: $g-header-height-medium;
+    }
+
+    @include breakpoint('large+') {
+      top: $g-header-height-large;
+    }
+
+    @include breakpoint('xlarge+') {
+      top: $g-header-height-xlarge;
+    }
+
     .filter-tag-set {
       display: flex;
       flex-direction: row;

--- a/src/scss/styleguide-extend.scss
+++ b/src/scss/styleguide-extend.scss
@@ -20,6 +20,12 @@ body {
   font-family: $font-family;
 }
 
+html,
+body {
+  // the styleguide sets this to hidden. But that breaks 'position: sticky'.
+  overflow-x: initial;
+}
+
 ul,
 li {
   list-style: none;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -87,3 +87,11 @@ $mapbox-controls-border: 2px solid $color-white;
 $mapbox-controls-size: 1.75em;
 
 $loading-overlay-opacity: .6;
+
+// explicitly define header heights that are calculated in the styleguide
+// because we need them for the position: sticky elements
+$g-header-height-xsmall: #{map-get($headerHeights, 'xsmall')}; /* 1 */
+$g-header-height-medium: #{map-get($headerHeights, 'medium')}; /* 1 */
+$g-header-height-large: #{map-get($headerHeights, 'large')}; /* 1 */
+$g-header-height-xlarge: #{map-get($headerHeights, 'xlarge')}; /* 1 */
+


### PR DESCRIPTION
https://trello.com/c/OTCYNPsV/246-ux-visually-related-tab

This solves for the sticky artObject on artObject page

Note that this is only using css for the position: sticky behavior. This is good support now, it just won't work for IE 11. If we really need it to work for IE 11, we'll have to add a javascript fallback and it will require more effort. I'm hoping we don't need to do that since the absence of this behavior is not really "broken", it's just not optimal.

http://caniuse.com/#search=sticky
